### PR TITLE
Feat lifecycle hooks

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -15,7 +15,7 @@ runtimes and platforms as well.
 
 ## On the roadmap (Not implemented yet)
 
-- Component lifecycle hooks/effects for asynchronous calls and cleanup logic
+- Component lifecycle hooks for asynchronous calls and cleanup logic
 
 ## Integration with Cargo
 

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -2,7 +2,7 @@ import { AST, tag, VComponent, VElement, VMode, VText, VType } from "./mod.ts";
 import { state } from "./state/mod.ts";
 import { assert, assertEquals } from "./test_deps.ts";
 
-Deno.test("should create a vText", async (t) => {
+Deno.test("AST: vText", async (t) => {
   const vText = AST.create("hello world");
 
   await t.step('should have type equals "vText"', () => {
@@ -12,11 +12,11 @@ Deno.test("should create a vText", async (t) => {
     assertEquals((<VText<unknown>> vText).text, "hello world");
   });
   await t.step('should have empty prop "eventRefs"', () => {
-    assertEquals((<VText<unknown>> vText).eventsRefs, []);
+    assertEquals((<VText<unknown>> vText).eventRefs, []);
   });
 });
 
-Deno.test('should create a "vElement"', async (t) => {
+Deno.test("AST: vElement", async (t) => {
   const vElement = AST.create(
     tag("div", { class: "button" }, ["hello"]),
   );
@@ -25,7 +25,7 @@ Deno.test('should create a "vElement"', async (t) => {
   });
 });
 
-Deno.test('should create "vComponent"', async (t) => {
+Deno.test("AST: vComponent", async (t) => {
   const vNode = <VComponent<unknown>> AST.create(tag(App, null, []));
 
   await t.step('should have type "vComponent"', () => {
@@ -51,7 +51,7 @@ Deno.test('should create "vComponent"', async (t) => {
 Deno.test("should update vComponent", async (t) => {
   const vNode = <VComponent<unknown>> AST.create(tag(App, null, []));
 
-  await t.step('Attribute: "class" before AST update', () => {
+  await t.step("should have attribute class before update", () => {
     // @ts-ignore
     assert((<VComponent<unknown>> vNode).ast?.props?.class === "blue");
   });

--- a/src/hooks/deps.ts
+++ b/src/hooks/deps.ts
@@ -1,0 +1,1 @@
+export { scope } from "../mod.ts";

--- a/src/hooks/deps.ts
+++ b/src/hooks/deps.ts
@@ -1,1 +1,1 @@
-export { scope } from "../mod.ts";
+export { scope, VMode } from "../mod.ts";

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -1,13 +1,29 @@
-import { scope } from "./deps.ts";
+import { scope, VMode } from "./deps.ts";
 
 export function onMount(fn: () => () => void) {
-  scope[scope.length - 1].hooks = {
-    onMount: [fn],
-  };
+  const vComponent = scope[scope.length - 1];
+
+  if (vComponent.mode === VMode.NotCreated) {
+    if (!vComponent.hooks) {
+      vComponent.hooks = {};
+    }
+
+    vComponent.hooks.onMount = Array.isArray(vComponent.hooks.onMount)
+      ? [...vComponent.hooks.onMount, fn]
+      : [fn];
+  }
 }
 
 export function onDestroy(fn: () => void) {
-  scope[scope.length - 1].hooks = {
-    onDestroy: [fn],
-  };
+  const vComponent = scope[scope.length - 1];
+
+  if (vComponent.mode === VMode.NotCreated) {
+    if (!vComponent.hooks) {
+      vComponent.hooks = {};
+    }
+
+    vComponent.hooks.onDestroy = Array.isArray(vComponent.hooks.onDestroy)
+      ? [...vComponent.hooks.onDestroy, fn]
+      : [fn];
+  }
 }

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -1,0 +1,13 @@
+import { scope } from "./deps.ts";
+
+export function onMount(fn: () => () => void) {
+  scope[scope.length - 1].hooks = {
+    onMount: [fn],
+  };
+}
+
+export function onDestroy(fn: () => void) {
+  scope[scope.length - 1].hooks = {
+    onDestroy: [fn],
+  };
+}

--- a/src/hooks/mod.ts
+++ b/src/hooks/mod.ts
@@ -1,0 +1,1 @@
+export { onMount, onDestroy } from "./lifecycle.ts"

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,8 +1,9 @@
 // Cargo Parcel – Version 0.1.63
 export { tag } from "./tag.ts";
-export { componentsCache } from "./registry.ts";
 export {
   AST,
+  scope,
+  type VBase,
   type VComponent,
   type VElement,
   VMode,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,4 @@
-// Cargo Parcel – Version 0.1.63
+// Cargo Parcel – Version 0.1.64
 export { tag } from "./tag.ts";
 export {
   AST,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,6 +6,7 @@ export {
   type VBase,
   type VComponent,
   type VElement,
+  type VHooks,
   VMode,
   type VNode,
   type VNodeRef,

--- a/src/platform/browser/diff/deps.ts
+++ b/src/platform/browser/diff/deps.ts
@@ -1,4 +1,5 @@
 export {
+  type VBase,
   type VComponent,
   type VElement,
   type VNode,

--- a/src/platform/browser/diff/deps.ts
+++ b/src/platform/browser/diff/deps.ts
@@ -2,6 +2,7 @@ export {
   type VBase,
   type VComponent,
   type VElement,
+  type VHooks,
   type VNode,
   type VNodeRef,
   type VText,

--- a/src/platform/browser/diff/diff.ts
+++ b/src/platform/browser/diff/diff.ts
@@ -22,9 +22,9 @@ export function diff(
 ): ChangeSet<unknown>[] {
   let { vNode, previousVNode, parentVNode, node } = props;
 
-  parentVNode = skipVComponents(parentVNode);
+  parentVNode = parentVNode ? skipVComponents(parentVNode) : undefined;
   vNode = skipVComponents(vNode);
-  previousVNode = skipVComponents(previousVNode);
+  previousVNode = previousVNode ? skipVComponents(previousVNode) : undefined;
 
   if (toBeHydrated(node, vNode, previousVNode)) {
     return hydrate({
@@ -98,6 +98,9 @@ function skipVComponents<T>(
   vNode: VNode<T>,
 ): VElement<T> | VText<T> | undefined {
   if (vNode?.type === VType.COMPONENT) {
+    if (vNode.ast && vNode.hooks) {
+      vNode.ast.hooks = { ...vNode.hooks };
+    }
     return skipVComponents(vNode.ast);
   }
   return vNode || undefined;

--- a/src/platform/browser/diff/element.ts
+++ b/src/platform/browser/diff/element.ts
@@ -39,6 +39,7 @@ export interface ElementChangeSet extends
 }
 
 export function element(change: ElementChangeSet): void {
+  // Create an new element in the dom
   if (change.action === "create") {
     return create(<CreateElementPayload> change.payload);
   }
@@ -76,6 +77,10 @@ function attach(payload: AttachElementPayload): void {
   if (payload.vNode.type === VType.ELEMENT && payload.vNode.nodeRef) {
     (<Node> payload.parentVNode.nodeRef)?.appendChild(payload.vNode.nodeRef);
   }
+  // Run lifecycle "onMount" dhooks associated with this element.
+  payload.vNode.hooks?.onMount?.forEach((hook) => {
+    hook();
+  });
 }
 
 function replace(payload: ReplaceElementPayload): void {
@@ -107,6 +112,10 @@ function remove(payload: DeleteElementPayload): void {
   (<Node> payload.parentVNode.nodeRef).removeChild(
     <Node> payload.vNode.nodeRef,
   );
+  // Run lifecycle "onDestroy" hooks associated with this element.
+  payload.vNode.hooks?.onDestroy?.forEach((hook) => {
+    hook();
+  });
 }
 
 function createElement(vNode: VElement<Node>, parentNode: Node): Node {

--- a/src/platform/browser/diff/hydrate.ts
+++ b/src/platform/browser/diff/hydrate.ts
@@ -35,8 +35,6 @@ function element(
 ) {
   const changes: ChangeSet<unknown>[] = [];
 
-  console.log(props);
-
   // Replace dom node with effective vnode type
   if (props.node.nodeName.toLowerCase() !== props.vNode.tag) {
     changes.push({

--- a/src/platform/browser/diff/hydrate.ts
+++ b/src/platform/browser/diff/hydrate.ts
@@ -35,6 +35,8 @@ function element(
 ) {
   const changes: ChangeSet<unknown>[] = [];
 
+  console.log(props);
+
   // Replace dom node with effective vnode type
   if (props.node.nodeName.toLowerCase() !== props.vNode.tag) {
     changes.push({
@@ -45,10 +47,13 @@ function element(
   } else {
     // Link current dom node with the vnode
     props.vNode.nodeRef = props.node;
+    props.vNode.hooks?.onMount?.forEach((hook) => {
+      hook();
+    });
   }
 
   // Attach events to the dom node
-  props.vNode.eventsRefs?.forEach((eventRef) => {
+  props.vNode.eventRefs?.forEach((eventRef) => {
     changes.push(
       <EventChangeSet> {
         action: "create",

--- a/src/platform/browser/diff/render.ts
+++ b/src/platform/browser/diff/render.ts
@@ -37,7 +37,7 @@ function renderElement(
 ): ChangeSet<unknown>[] {
   const changes: ChangeSet<unknown>[] = [];
 
-  // Create DOM node and link it to the vnode
+  // Create DOM node and link it to the vNode
   changes.push({
     type: "element",
     action: "create",
@@ -58,7 +58,7 @@ function renderElement(
   });
 
   // Attach events
-  vNode.eventsRefs.forEach((event) => {
+  vNode.eventRefs.forEach((event) => {
     changes.push({
       type: "event",
       action: "create",

--- a/src/platform/browser/diff/update.ts
+++ b/src/platform/browser/diff/update.ts
@@ -148,25 +148,25 @@ export function updateEvents(
   const changes: EventChangeSet[] = [];
 
   // Remove previous events
-  previousvNode?.eventsRefs?.forEach((previousEvent) => {
+  previousvNode?.eventRefs?.forEach((eventRef) => {
     changes.push({
       action: "delete",
       type: "event",
       payload: {
         vNode: previousvNode,
-        ...previousEvent,
+        ...eventRef,
       },
     });
   });
 
   // Attach new events
-  vNode?.eventsRefs?.forEach((event) => {
+  vNode?.eventRefs?.forEach((eventRef) => {
     changes.push({
       action: "create",
       type: "event",
       payload: {
         vNode,
-        ...event,
+        ...eventRef,
       },
     });
   });
@@ -200,7 +200,7 @@ export function updateChildren(
   if (props.previousVNode && Array.isArray(props.previousVNode.children)) {
     previousChildren = [...props.previousVNode.children];
   }
-  props.vNode?.children?.forEach((child, index) => {
+  props.vNode?.children?.forEach((child) => {
     changes.push(...diff({
       parentVNode: props.vNode,
       vNode: child,

--- a/src/platform/server/render.test.tsx
+++ b/src/platform/server/render.test.tsx
@@ -21,21 +21,21 @@ Deno.test(
       );
     });
 
-    await t.step("should render self closing compoent", () => {
+    await t.step("should render self closing component as string", () => {
       assertEquals(
         renderToString(<Title />),
         "<h1>Hello World!</h1>",
       );
     });
 
-    await t.step("should render div with text", () => {
+    await t.step("should render div with text as string", () => {
       assertEquals(
         renderToString(<div class="bg-red">Hello</div>),
         '<div class="bg-red">Hello</div>',
       );
     });
 
-    await t.step("should render image", () => {
+    await t.step("should render image as string", () => {
       assertEquals(
         renderToString(
           <img
@@ -46,7 +46,7 @@ Deno.test(
         '<img href="https://cargo.wtf" alt="A very interesting description :-)"/>',
       );
     });
-    await t.step("should render svg", () => {
+    await t.step("should render svg as string", () => {
       assertEquals(
         renderToString(
           <svg

--- a/src/platform/server/render.test.tsx
+++ b/src/platform/server/render.test.tsx
@@ -12,30 +12,30 @@ function Headline(props: JSX.ElementProps) {
 }
 
 Deno.test(
-  "Platform Server: Render to string",
+  "Platform Server:",
   async (t) => {
-    await t.step("Component with children: <Headline>Hello<Headline/>", () => {
+    await t.step("should render headline component with text", () => {
       assertEquals(
         renderToString(<Headline>Hello</Headline>),
         "<h1>Hello</h1>",
       );
     });
 
-    await t.step("Component without children: <Title/>", () => {
+    await t.step("should render self closing compoent", () => {
       assertEquals(
         renderToString(<Title />),
         "<h1>Hello World!</h1>",
       );
     });
 
-    await t.step("HTML Tag: <div>Hello</div>", () => {
+    await t.step("should render div with text", () => {
       assertEquals(
         renderToString(<div class="bg-red">Hello</div>),
         '<div class="bg-red">Hello</div>',
       );
     });
 
-    await t.step("HTML Single Tag: <img/>", () => {
+    await t.step("should render image", () => {
       assertEquals(
         renderToString(
           <img
@@ -46,7 +46,7 @@ Deno.test(
         '<img href="https://cargo.wtf" alt="A very interesting description :-)"/>',
       );
     });
-    await t.step("SVG Element: <svg>", () => {
+    await t.step("should render svg", () => {
       assertEquals(
         renderToString(
           <svg

--- a/src/platform/server/render.ts
+++ b/src/platform/server/render.ts
@@ -32,22 +32,18 @@ export function renderToString(
 }
 
 function stringify<T>(vNode: VNode<T>): string {
-  // VNode is null or undefined
   if (!vNode) return "";
 
-  // VNode is VText
   if (
     vNode.type === VType.TEXT
   ) {
     return escapeHtml((<VText<T>> vNode).text.toString());
   }
 
-  // VNode is VElement
   if (vNode.type === VType.ELEMENT) {
     return elementToString(<VElement<T>> vNode);
   }
 
-  //VNode is VComponent
   if (vNode.type === VType.COMPONENT) {
     return stringify(<VComponent<T>> vNode.ast);
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,9 +1,0 @@
-import type { VComponent } from "./ast.ts";
-
-interface CompontentsCache {
-  toCreate: VComponent<unknown>[];
-}
-
-export const componentsCache: CompontentsCache = {
-  toCreate: [],
-};

--- a/src/state/deps.ts
+++ b/src/state/deps.ts
@@ -1,1 +1,1 @@
-export { componentsCache, type VComponent } from "../mod.ts";
+export { scope, type VComponent } from "../mod.ts";

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -1,5 +1,5 @@
 import { VMode } from "../mod.ts";
-import { componentsCache, VComponent } from "./deps.ts";
+import { scope, VComponent } from "./deps.ts";
 import { cycle } from "./mod.ts";
 
 export interface VStateComponent<T> extends VComponent<unknown> {
@@ -15,12 +15,11 @@ export type State<T> = [
 const stateCache: State<unknown>[] = [];
 
 export function state<T>(value: T): State<T> {
-  if (!componentsCache.toCreate.length) {
+  if (!scope.length) {
     throw Error("State could neither be created nor returned!");
   }
 
-  const vComponent: VStateComponent<T> =
-    componentsCache.toCreate[componentsCache.toCreate.length - 1];
+  const vComponent: VStateComponent<T> = scope[scope.length - 1];
 
   // If state is left in the current VComponent scope return it.
   if (stateCache.length) {


### PR DESCRIPTION
This PR introduces lifecycle hooks for components. This allows you to trigger async code at certain points in a component lifecycle. For now we introduce the following 2 hooks:

* *onMount* is triggered after the html node associated with the component is rendered / hydrated in the dom.
* *onDelete* is triggered after the html node associated with the component is removed from the dom.

The two hooks are exported from `/hooks/mod.ts`