### PR TITLE
feat: support onDestroy hook returned by an onMount hook

### DIFF
--- a/src/platform/browser/diff/element.ts
+++ b/src/platform/browser/diff/element.ts
@@ -77,9 +77,16 @@ function attach(payload: AttachElementPayload): void {
   if (payload.vNode.type === VType.ELEMENT && payload.vNode.nodeRef) {
     (<Node> payload.parentVNode.nodeRef)?.appendChild(payload.vNode.nodeRef);
   }
-  // Run lifecycle "onMount" dhooks associated with this element.
+  // Run lifecycle "onMount" hooks associated with this element.
   payload.vNode.hooks?.onMount?.forEach((hook) => {
-    hook();
+    const onDestroy = hook();
+    if (typeof onDestroy === "function" && payload.vNode.hooks) {
+      if (Array.isArray(payload.vNode.hooks.onDestroy)) {
+        payload.vNode.hooks.onDestroy.push(onDestroy);
+        return;
+      }
+      payload.vNode.hooks.onDestroy = [onDestroy];
+    }
   });
 }
 

--- a/src/platform/browser/diff/hydrate.ts
+++ b/src/platform/browser/diff/hydrate.ts
@@ -46,7 +46,14 @@ function element(
     // Link current dom node with the vnode
     props.vNode.nodeRef = props.node;
     props.vNode.hooks?.onMount?.forEach((hook) => {
-      hook();
+      const onDestroy = hook();
+      if (typeof onDestroy === "function" && props.vNode.hooks) {
+        if (Array.isArray(props.vNode.hooks.onDestroy)) {
+          props.vNode.hooks.onDestroy.push(onDestroy);
+          return;
+        }
+        props.vNode.hooks.onDestroy = [onDestroy];
+      }
     });
   }
 

--- a/src/platform/browser/diff/update.ts
+++ b/src/platform/browser/diff/update.ts
@@ -39,6 +39,7 @@ function updateElement(
   let skipPrevious = false;
 
   vNode.nodeRef = <Node> previousVNode.nodeRef;
+  vNode.hooks = previousVNode.hooks;
 
   // Tag did change
   if (vNode.tag !== (<VElement<Node>> previousVNode).tag) {


### PR DESCRIPTION
Add support to handle onDestroy function returned by a onMount hook, in the implementation of platform browser.

```ts
import { onMount } from "parcel/hooks/mod.ts"

function List(){
  onMount(()=>{
    console.log("List mounted");
    return ()=>{
      console.log("List destroyed");
    }
  });
  return <li>Hello</li>
}
```