### PR TITLE
feat: add beforeRender task

### DIFF
--- a/.dev/import_map.json
+++ b/.dev/import_map.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "std/": "https://deno.land/std@0.180.0/",
-    "cargo/": "https://deno.land/x/cargo@0.1.49/"
+    "cargo/": "https://deno.land/x/cargo@0.1.49/",
+    "inspect/": "https://deno.land/x/cargo_inspect@0.1.49/"
   }
 }

--- a/.dev/import_map.json
+++ b/.dev/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "std/": "https://deno.land/std@0.180.0/",
-    "cargo/": "https://deno.land/x/cargo@0.1.49/",
-    "inspect/": "https://deno.land/x/cargo_inspect@0.1.49/"
+    "cargo/": "https://deno.land/x/cargo@0.1.50/",
+    "inspect/": "https://deno.land/x/cargo_inspect@0.1.50/"
   }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,4 @@
-// Cargo Parcel – Version 0.1.77
+// Cargo Parcel – Version 0.1.78
 export { tag } from "./tag.ts";
 export {
   AST,


### PR DESCRIPTION
The following changes are introduced with this PR.

* New `beforeRender` task for plugins
* Plugin tasks are not allowed to run async code. This is to make sure we run the rendered part sync to support hooks and cleanup functions per request.